### PR TITLE
Use scipy.stats.studentized_range with tukey hsd when available

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -153,8 +153,13 @@ def get_tukeyQcrit2(k, df, alpha=0.05):
 
     not enough error checking for limitations
     '''
-    from statsmodels.stats.libqsturng import qsturng
-    return qsturng(1-alpha, k, df)
+    try:
+        # Studentized Range is not available below SciPy 1.7.
+        from scipy.stats import studentized_range
+        return studentized_range.ppf(1 - alpha, k, df)
+    except ImportError:
+        from statsmodels.stats.libqsturng import qsturng
+        return qsturng(1-alpha, k, df)
 
 
 def get_tukey_pvalue(k, df, q):
@@ -171,9 +176,13 @@ def get_tukey_pvalue(k, df, q):
         quantile value of Studentized Range
 
     '''
-
-    from statsmodels.stats.libqsturng import psturng
-    return psturng(q, k, df)
+    try:
+        # Studentized Range is not available below SciPy 1.7.
+        from scipy.stats import studentized_range
+        return 1 - studentized_range.cdf(q, k, df)
+    except ImportError:
+        from statsmodels.stats.libqsturng import psturng
+        return psturng(q, k, df)
 
 
 def Tukeythreegene(first, second, third):

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -76,6 +76,13 @@ from statsmodels.stats.multitest import multipletests, _ecdf as ecdf, fdrcorrect
 from statsmodels.graphics import utils
 from statsmodels.tools.sm_exceptions import ValueWarning
 
+try:
+    from scipy.stats import studentized_range
+    qsturng = studentized_range.ppf
+    psturng = studentized_range.sf
+except ImportError:
+    from statsmodels.stats.libqsturng import qsturng, psturng
+
 qcrit = '''
   2     3     4     5     6     7     8     9     10
 5   3.64 5.70   4.60 6.98   5.22 7.80   5.67 8.42   6.03 8.91   6.33 9.32   6.58 9.67   6.80 9.97   6.99 10.24
@@ -153,13 +160,7 @@ def get_tukeyQcrit2(k, df, alpha=0.05):
 
     not enough error checking for limitations
     '''
-    try:
-        # Studentized Range is not available below SciPy 1.7.
-        from scipy.stats import studentized_range
-        return studentized_range.ppf(1 - alpha, k, df)
-    except ImportError:
-        from statsmodels.stats.libqsturng import qsturng
-        return qsturng(1-alpha, k, df)
+    return qsturng(1-alpha, k, df)
 
 
 def get_tukey_pvalue(k, df, q):
@@ -176,13 +177,7 @@ def get_tukey_pvalue(k, df, q):
         quantile value of Studentized Range
 
     '''
-    try:
-        # Studentized Range is not available below SciPy 1.7.
-        from scipy.stats import studentized_range
-        return 1 - studentized_range.cdf(q, k, df)
-    except ImportError:
-        from statsmodels.stats.libqsturng import psturng
-        return psturng(q, k, df)
+    return psturng(q, k, df)
 
 
 def Tukeythreegene(first, second, third):

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -381,7 +381,7 @@ def test_tukeyhsd():
         [-19.016667, -37.204253, -0.8290806, 0.037710044]])
 
     m_r = [94.39167, 102.54167,  91.13333, 118.20000,  99.18333]
-    myres = tukeyhsd(m_r, 6, 110.8, alpha=0.05, df=4)
+    myres = tukeyhsd(m_r, 6, 110.8254416667, alpha=0.05, df=4)
     pairs, reject, meandiffs, std_pairs, confint, q_crit = myres[:6]
     assert_almost_equal(meandiffs, res[:, 0], decimal=5)
     assert_almost_equal(confint, res[:, 1:3], decimal=2)
@@ -390,7 +390,7 @@ def test_tukeyhsd():
     # check p-values (divergence of high values is expected)
     small_pvals_idx = [2, 5, 7, 9]
     assert_allclose(myres[8][small_pvals_idx], res[small_pvals_idx, 3],
-                    rtol=1e-2)
+                    rtol=1e-3)
 
 
 def test_local_fdr():

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -390,7 +390,7 @@ def test_tukeyhsd():
     # check p-values (divergence of high values is expected)
     small_pvals_idx = [2, 5, 7, 9]
     assert_allclose(myres[8][small_pvals_idx], res[small_pvals_idx, 3],
-                    rtol=1e-3)
+                    rtol=1e-2)
 
 
 def test_local_fdr():

--- a/statsmodels/stats/tests/test_pairwise.py
+++ b/statsmodels/stats/tests/test_pairwise.py
@@ -365,4 +365,4 @@ class TestTuckeyHSD4(CheckTuckeyHSDMixin):
         cls.reject2 = np.array([False, False, False,  True, False, False,  True, False,  True, False])
 
     def test_hochberg_intervals(self):
-        assert_almost_equal(self.res.halfwidths, self.halfwidth2, 14)
+        assert_almost_equal(self.res.halfwidths, self.halfwidth2, 4)


### PR DESCRIPTION
- [ ] closes #xxxx 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 


This change allows StatsModels to use SciPy's numerically integrated PPF and SF rather than statmodels' interpolated versions. The speed is maintained, and the results are more accurate.

We extensively tested the accuracy of SciPy's studentized range in this [poster](https://zenodo.org/record/5151976#.YekY3_7MKUk) created for the SciPy conference. The strong results there indicate high precision.
